### PR TITLE
Add Snowflake AI prompt rules for SQL, Cortex AI, Snowpark Python, and dbt

### DIFF
--- a/prompts/snowflake-cortex/aiprompt.json
+++ b/prompts/snowflake-cortex/aiprompt.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Snowflake Cortex AI",
+    "description": "Expert guidance for Cortex AI Functions (AI_COMPLETE, AI_CLASSIFY, AI_EXTRACT, etc.) and Cortex Search for RAG applications in Snowflake",
+    "type": "rule",
+    "slug": "snowflake-cortex-rule",
+    "development_process": ["plan", "implement", "test"],
+    "dev_categories": ["backend", "db", "ai"],
+    "tags": ["ai", "llm", "cortex", "unstructured-data", "document-intelligence"],
+    "techStack": {
+      "framework": "cortex",
+      "service": "snowflake"
+    },
+    "ai_editor": ["cursor", "windsurf", "cline", "copilot", "zed"],
+    "author": {
+      "name": "Snowflake DevRel",
+      "url": "https://github.com/Snowflake-Labs"
+    },
+    "model": ["reasoning", "chat"],
+    "version": "1.0",
+    "files": ["rule-snowflake-cortex.mdc"],
+    "published": true
+  }
+]

--- a/prompts/snowflake-cortex/rule-snowflake-cortex.mdc
+++ b/prompts/snowflake-cortex/rule-snowflake-cortex.mdc
@@ -1,0 +1,146 @@
+---
+description: Expert guidance for Snowflake Cortex AI Functions and Cortex Search for RAG applications
+globs: "**/*.sql, **/*.py"
+---
+
+# Snowflake Cortex AI
+
+## Overview
+
+You are an expert in Snowflake Cortex — the AI layer including Cortex AI Functions (SQL-callable LLM/ML functions) and Cortex Search (managed hybrid search for RAG). All models run inside Snowflake with no data leaving the platform.
+
+## Available AI Functions
+
+Use these names — they are the current versions:
+
+| Function | Purpose |
+|----------|---------|
+| `AI_COMPLETE` | General-purpose LLM completion (text, images, documents) |
+| `AI_CLASSIFY` | Classify text or images into user-defined categories |
+| `AI_FILTER` | Returns TRUE/FALSE for text or image input |
+| `AI_AGG` | Aggregate insights across multiple rows of text |
+| `AI_EMBED` | Generate embedding vectors for similarity search |
+| `AI_EXTRACT` | Extract structured information from text/images/documents |
+| `AI_SENTIMENT` | Extract sentiment score from text |
+| `AI_SUMMARIZE_AGG` | Summarize across multiple rows of text |
+| `AI_SIMILARITY` | Calculate embedding similarity between two inputs |
+| `AI_TRANSCRIBE` | Transcribe audio/video files from stages |
+| `AI_PARSE_DOCUMENT` | Extract text (OCR) or text+layout from documents |
+| `AI_REDACT` | Redact PII from text |
+| `AI_TRANSLATE` | Translate between supported languages |
+
+## Helper Functions
+
+- `TO_FILE('@stage', 'filename')` — Create file reference for AI_COMPLETE document processing.
+- `AI_COUNT_TOKENS(model, text)` — Check token count before calling a model.
+- `PROMPT('template {0}', arg)` — Build prompt objects for AI_COMPLETE.
+- `TRY_COMPLETE` — Like AI_COMPLETE but returns NULL on failure instead of error.
+
+## AI_COMPLETE — The Primary Function
+
+```sql
+-- Simple text completion
+SELECT AI_COMPLETE(
+  MODEL => 'claude-4-sonnet',
+  PROMPT => 'Summarize this review: ' || review_text
+) FROM reviews;
+
+-- Document processing with PROMPT and TO_FILE
+SELECT AI_COMPLETE(
+  MODEL => 'claude-4-sonnet',
+  PROMPT => PROMPT('Extract the invoice total from {0}', TO_FILE('@docs', 'invoice.pdf'))
+);
+
+-- Structured JSON output
+SELECT AI_COMPLETE(
+  MODEL => 'claude-4-sonnet',
+  PROMPT => 'Extract name, email, and company as JSON from: ' || raw_text
+)::VARIANT AS extracted FROM contacts;
+```
+
+Available models: claude-4-opus, claude-4-sonnet, claude-sonnet-4-5, claude-opus-4-5, claude-haiku-4-5, gemini-3-pro, llama3.1-70b, llama3.1-8b, llama3.3-70b, mistral-large2, mistral-small2, deepseek-r1.
+
+## AI_CLASSIFY — Classification
+
+```sql
+SELECT AI_CLASSIFY(ticket_text, ['billing', 'technical', 'account', 'other']) AS category FROM tickets;
+
+-- Multi-label classification
+SELECT AI_CLASSIFY(input, categories, {'output_mode': 'multi'});
+```
+
+## AI_FILTER — Boolean Filtering
+
+```sql
+SELECT * FROM reviews WHERE AI_FILTER(review_text, 'mentions product quality issues');
+```
+
+## AI_AGG — Cross-Row Aggregation
+
+```sql
+SELECT AI_AGG(feedback_text, 'What are the top 3 themes across all feedback?') FROM customer_feedback;
+```
+
+## AI_EXTRACT — Entity Extraction
+
+```sql
+SELECT AI_EXTRACT(email_body, 'meeting date', 'attendees', 'action items') FROM emails;
+```
+
+## AI_SENTIMENT — Sentiment Analysis
+
+```sql
+-- Returns score from -1 (negative) to 1 (positive)
+SELECT review_text, AI_SENTIMENT(review_text) AS sentiment FROM product_reviews;
+```
+
+## AI_EMBED — Vector Embeddings
+
+```sql
+SELECT AI_EMBED(description) AS embedding FROM products;
+```
+
+## AI_PARSE_DOCUMENT — Document OCR and Layout
+
+```sql
+SELECT AI_PARSE_DOCUMENT(
+  TO_FILE('@docs', 'contract.pdf'),
+  MODE => 'LAYOUT'
+) AS parsed_content;
+```
+
+## AI_TRANSCRIBE — Audio/Video Transcription
+
+```sql
+SELECT AI_TRANSCRIBE(TO_FILE('@media', 'call_recording.mp3')) AS transcript;
+```
+
+## AI_REDACT — PII Redaction
+
+```sql
+SELECT AI_REDACT(customer_notes) AS redacted FROM support_cases;
+```
+
+## Key Patterns
+
+- **Process documents**: Use AI_COMPLETE with TO_FILE() and PROMPT() for PDFs, Word docs, spreadsheets.
+- **Batch processing**: AI Functions are optimized for throughput on large SQL tables.
+- **Low-latency**: For interactive use cases, prefer the REST API (Complete API, Embed API, Agents API).
+- **Cortex Guard**: Add guard rails to AI_COMPLETE to filter unsafe content (uses Llama Guard 3).
+
+## Privileges Required
+
+- Users need both `USE AI FUNCTIONS` account privilege AND the `SNOWFLAKE.CORTEX_USER` database role.
+- Both are granted to PUBLIC by default. Revoke from PUBLIC and grant to specific roles for tighter control.
+
+## Cost Awareness
+
+- Cost is based on tokens processed per model. Check token counts with AI_COUNT_TOKENS before large batch jobs.
+- Different models have different costs per million tokens — check the Snowflake Service Consumption Table.
+
+## Anti-Patterns
+
+- Do NOT use the old function names (COMPLETE, CLASSIFY_TEXT, EXTRACT_ANSWER, SENTIMENT, TRANSLATE, etc.) — use AI_* versions.
+- Do NOT pass entire large tables through AI_COMPLETE row-by-row without cost estimation first.
+- Do NOT use AI_COMPLETE for simple classification — use AI_CLASSIFY instead (purpose-built, cheaper).
+- Do NOT hardcode model names without considering regional availability.

--- a/prompts/snowflake-dbt/aiprompt.json
+++ b/prompts/snowflake-dbt/aiprompt.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Snowflake dbt Integration",
+    "description": "Expert guidance for using dbt with the Snowflake adapter, including dynamic tables, incremental models, and Snowflake-specific configurations",
+    "type": "rule",
+    "slug": "snowflake-dbt-rule",
+    "development_process": ["plan", "implement", "test"],
+    "dev_categories": ["backend", "db"],
+    "tags": ["dbt", "data-transformation", "dynamic-tables", "incremental"],
+    "techStack": {
+      "framework": "dbt",
+      "service": "snowflake"
+    },
+    "ai_editor": ["cursor", "windsurf", "cline", "copilot", "zed"],
+    "author": {
+      "name": "Snowflake DevRel",
+      "url": "https://github.com/Snowflake-Labs"
+    },
+    "model": ["reasoning", "chat"],
+    "version": "1.0",
+    "files": ["rule-snowflake-dbt.mdc"],
+    "published": true
+  }
+]

--- a/prompts/snowflake-dbt/rule-snowflake-dbt.mdc
+++ b/prompts/snowflake-dbt/rule-snowflake-dbt.mdc
@@ -1,0 +1,162 @@
+---
+description: Expert guidance for using dbt with the Snowflake adapter including dynamic tables, incremental models, and Snowflake-specific configs
+globs: "**/*.sql, **/*.yml, **/*.yaml"
+---
+
+# Snowflake dbt Integration
+
+## Setup
+
+Install: `pip install dbt-snowflake`
+
+### profiles.yml
+
+```yaml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: myaccount
+      user: myuser
+      password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
+      role: transformer
+      database: analytics
+      warehouse: transforming
+      schema: public
+      threads: 4
+```
+
+Verify: `dbt debug`
+
+## Materializations
+
+Snowflake supports all standard materializations plus Snowflake-specific ones:
+
+- **view** (default) — CREATE VIEW
+- **table** — CREATE TABLE AS SELECT
+- **incremental** — MERGE or INSERT/DELETE pattern
+- **ephemeral** — CTE, not materialized
+- **dynamic_table** — Snowflake Dynamic Table (auto-refreshing)
+
+## Dynamic Tables in dbt
+
+```sql
+-- models/my_dynamic_table.sql
+{{
+  config(
+    materialized='dynamic_table',
+    snowflake_warehouse='transforming',
+    target_lag='1 hour'
+  )
+}}
+SELECT
+  customer_id,
+  SUM(amount) AS lifetime_value,
+  MAX(order_date) AS last_order_date
+FROM {{ ref('stg_orders') }}
+GROUP BY 1
+```
+
+With clustering (dbt-snowflake 1.11+):
+
+```sql
+{{ config(materialized='dynamic_table', target_lag='5 minutes', cluster_by=['session_start', 'user_id']) }}
+```
+
+## Incremental Models
+
+```sql
+{{
+  config(
+    materialized='incremental',
+    unique_key='event_id',
+    incremental_strategy='merge',
+    on_schema_change='sync_all_columns'
+  )
+}}
+SELECT * FROM {{ ref('stg_events') }}
+{% if is_incremental() %}
+  WHERE event_timestamp > (SELECT MAX(event_timestamp) FROM {{ this }})
+{% endif %}
+```
+
+## Snowflake-Specific Configurations
+
+```sql
+-- Cluster keys (for very large tables):
+{{ config(materialized='table', cluster_by=['event_date', 'region']) }}
+
+-- Transient tables (no Fail-safe, lower storage cost):
+{{ config(materialized='table', transient=true) }}
+
+-- Query tags (for workload attribution and cost tracking):
+{{ config(query_tag='finance_team_daily') }}
+
+-- Copy grants (preserve access when replacing objects):
+{{ config(copy_grants=true) }}
+
+-- Warehouse override per model:
+{{ config(snowflake_warehouse='large_wh') }}
+
+-- Secure views:
+{{ config(materialized='view', secure=true) }}
+```
+
+## Sources with Freshness
+
+```yaml
+# models/staging/_sources.yml
+sources:
+  - name: raw
+    database: raw_db
+    schema: jaffle_shop
+    tables:
+      - name: customers
+        loaded_at_field: _loaded_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
+```
+
+Reference: `{{ source('raw', 'customers') }}`
+
+## Testing
+
+```yaml
+# models/staging/schema.yml
+models:
+  - name: stg_customers
+    columns:
+      - name: customer_id
+        tests:
+          - unique
+          - not_null
+```
+
+## Common Commands
+
+- `dbt run` — Run all models
+- `dbt run --select my_model+` — Run model and all downstream
+- `dbt run --select +my_model` — Run model and all upstream
+- `dbt test` — Run all tests
+- `dbt build` — Run + test in dependency order
+- `dbt source freshness` — Check source data freshness
+
+## Best Practices
+
+- Use staging models (stg_*) to rename and type-cast source columns.
+- Use intermediate models for complex joins and business logic.
+- Use mart models for final business-facing tables.
+- Use incremental models for fact tables; use dynamic_table for streaming/near-real-time.
+- Set `on_schema_change='sync_all_columns'` on incremental models to handle schema evolution.
+- Use `copy_grants=true` to avoid permission issues when dbt replaces objects.
+- Use separate warehouses for dbt runs vs. analyst queries.
+
+## Anti-Patterns
+
+- Do NOT use `{{ this }}` without `{% if is_incremental() %}` guard.
+- Do NOT set cluster_by on small tables (< 1TB) — Snowflake auto-clusters well.
+- Do NOT use `materialized='table'` for everything — views are free and often sufficient.
+- Do NOT hardcode database/schema names — use `{{ ref() }}` and `{{ source() }}`.
+- Do NOT skip `dbt test` — data quality issues compound downstream.

--- a/prompts/snowflake-python/aiprompt.json
+++ b/prompts/snowflake-python/aiprompt.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Snowflake Snowpark Python",
+    "description": "Expert guidance for building data pipelines and ML workflows with Snowpark Python (DataFrames, UDFs, UDTFs, Stored Procedures)",
+    "type": "rule",
+    "slug": "snowflake-python-rule",
+    "development_process": ["plan", "implement", "test"],
+    "dev_categories": ["backend", "db"],
+    "tags": ["python", "data-engineering", "ml", "udf", "stored-procedure"],
+    "techStack": {
+      "framework": "python",
+      "service": "snowflake"
+    },
+    "ai_editor": ["cursor", "windsurf", "cline", "copilot", "zed"],
+    "author": {
+      "name": "Snowflake DevRel",
+      "url": "https://github.com/Snowflake-Labs"
+    },
+    "model": ["reasoning", "chat"],
+    "version": "1.0",
+    "files": ["rule-snowflake-python.mdc"],
+    "published": true
+  }
+]

--- a/prompts/snowflake-python/rule-snowflake-python.mdc
+++ b/prompts/snowflake-python/rule-snowflake-python.mdc
@@ -1,0 +1,154 @@
+---
+description: Expert guidance for building data pipelines and ML workflows with Snowpark Python
+globs: "**/*.py"
+---
+
+# Snowflake Snowpark Python
+
+## Overview
+
+Snowpark lets you write Python that runs server-side in Snowflake warehouses. Data never leaves Snowflake — no data movement to client machines. Core abstractions: Session, DataFrame, UDF, UDTF, UDAF, Stored Procedure.
+
+## Session — Connecting to Snowflake
+
+```python
+from snowflake.snowpark import Session
+
+connection_params = {
+    "account": "myaccount",
+    "user": "myuser",
+    "password": "mypassword",
+    "role": "my_role",
+    "warehouse": "my_wh",
+    "database": "my_db",
+    "schema": "my_schema"
+}
+session = Session.builder.configs(connection_params).create()
+```
+
+## DataFrame API — Query and Transform Data
+
+Snowpark DataFrames are lazy — operations build a query plan, executed on collect()/show().
+
+```python
+df = session.table("customers")
+df_filtered = df.filter(df["region"] == "US").select("name", "email", "revenue")
+df_agg = df.group_by("region").agg(sum("revenue").alias("total_revenue"))
+df_agg.show()
+```
+
+Key DataFrame operations: `.filter()`, `.select()`, `.group_by().agg()`, `.join()`, `.sort()`, `.with_column()`, `.drop()`, `.distinct()`, `.limit()`, `.union()`, `.flatten()`, `.write.save_as_table()`.
+
+## User-Defined Functions (UDFs)
+
+```python
+from snowflake.snowpark.functions import udf
+from snowflake.snowpark.types import StringType
+
+@udf(name="normalize_email", replace=True)
+def normalize_email(email: str) -> str:
+    return email.strip().lower() if email else None
+
+# Call in DataFrame:
+df.select(normalize_email("email").alias("clean_email")).show()
+```
+
+## Vectorized UDFs (for ML inference — much better performance)
+
+```python
+from snowflake.snowpark.functions import udf
+import pandas as pd
+
+@udf(name="predict_score", packages=["scikit-learn", "pandas"], replace=True)
+def predict_score(features: pd.Series) -> pd.Series:
+    import pickle, sys
+    model = pickle.load(open(sys.path[0] + "/model.pkl", "rb"))
+    return pd.Series(model.predict(features.values.reshape(-1, 1)))
+```
+
+## User-Defined Table Functions (UDTFs)
+
+```python
+from snowflake.snowpark.functions import udtf
+from snowflake.snowpark.types import StructType, StructField, StringType
+
+class Tokenizer:
+    def process(self, text: str):
+        for token in text.split():
+            yield (token,)
+
+tokenize = session.udtf.register(
+    Tokenizer,
+    output_schema=StructType([StructField("token", StringType())]),
+    input_types=[StringType()],
+    name="tokenize",
+    replace=True
+)
+```
+
+## Stored Procedures
+
+```python
+from snowflake.snowpark.functions import sproc
+
+@sproc(name="daily_etl", replace=True, packages=["snowflake-snowpark-python"])
+def daily_etl(session: Session) -> str:
+    raw = session.table("raw_events")
+    cleaned = raw.filter(raw["event_type"].is_not_null())
+    cleaned.write.mode("overwrite").save_as_table("cleaned_events")
+    return f"Processed {cleaned.count()} rows"
+
+# Call: session.call("daily_etl")
+```
+
+## Third-Party Packages
+
+```python
+session.add_packages("pandas", "scikit-learn==1.3.0", "xgboost")
+
+# Or at function level:
+@udf(packages=["numpy", "pandas"])
+def my_func(x: float) -> float:
+    import numpy as np
+    return float(np.sqrt(x))
+```
+
+Pin versions in production to avoid dependency drift.
+
+## File Access in UDFs/Stored Procedures
+
+```python
+# Static files (uploaded as dependencies):
+session.add_import("@my_stage/model.pkl")
+
+# Dynamic files (read at runtime):
+from snowflake.snowpark.files import SnowflakeFile
+with SnowflakeFile.open(file_path) as f:
+    data = f.read()
+```
+
+## pandas on Snowflake
+
+```python
+import modin.pandas as pd
+import snowflake.snowpark.modin.plugin
+
+df = pd.read_snowflake("my_table")
+result = df.groupby("region")["revenue"].sum()
+result.to_snowflake("regional_revenue", if_exists="replace")
+```
+
+## Best Practices
+
+- Use DataFrame API over raw SQL strings when building reusable Python pipelines.
+- Prefer vectorized UDFs (pandas batch input) for ML inference — 10-100x faster than scalar UDFs.
+- Pin package versions in production UDFs and stored procedures.
+- Use `is_permanent=True` + `stage_location` for UDFs/SPs that persist across sessions.
+- Use `session.add_import()` for model files, config files, and custom modules.
+
+## Anti-Patterns
+
+- Do NOT `collect()` large DataFrames to the client — process server-side.
+- Do NOT use Python loops over rows — use DataFrame operations or vectorized UDFs.
+- Do NOT forget to include `"snowflake-snowpark-python"` in packages for stored procedures.
+- Do NOT use mutable global state in UDFs — they run in parallel across partitions.

--- a/prompts/snowflake-sql/aiprompt.json
+++ b/prompts/snowflake-sql/aiprompt.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Snowflake SQL & Data Pipelines",
+    "description": "Expert guidance for Snowflake SQL, data pipelines (Dynamic Tables, Streams, Tasks, Snowpipe), semi-structured data, and cost optimization",
+    "type": "rule",
+    "slug": "snowflake-sql-rule",
+    "development_process": ["plan", "implement", "test"],
+    "dev_categories": ["backend", "db"],
+    "tags": ["data-warehouse", "analytics", "sql", "performance", "pipelines", "dynamic-tables", "streams"],
+    "techStack": {
+      "framework": "sql",
+      "service": "snowflake"
+    },
+    "ai_editor": ["cursor", "windsurf", "cline", "copilot", "zed"],
+    "author": {
+      "name": "Snowflake DevRel",
+      "url": "https://github.com/Snowflake-Labs"
+    },
+    "model": ["reasoning", "chat"],
+    "version": "1.0",
+    "files": ["rule-snowflake-sql.mdc"],
+    "published": true
+  }
+]

--- a/prompts/snowflake-sql/rule-snowflake-sql.mdc
+++ b/prompts/snowflake-sql/rule-snowflake-sql.mdc
@@ -1,0 +1,126 @@
+---
+description: Expert guidance for Snowflake SQL, data pipelines, and platform best practices
+globs: "**/*.sql, **/*.py, **/*.ts, **/*.js"
+---
+
+# Snowflake SQL & Data Pipelines
+
+## Overview
+
+You are an expert in Snowflake SQL development and data pipeline architecture, with deep knowledge of micro-partitions, columnar storage, virtual warehouses, Dynamic Tables, Streams, Tasks, and Snowpipe.
+
+## Key Principles
+
+- Write SQL that leverages Snowflake's architecture: columnar storage, automatic micro-partitioning, and elastic compute.
+- Prefer declarative transformations over procedural logic when possible.
+- Always consider cost implications: warehouse size, query duration, and data scanning.
+
+## Data Types and Semi-Structured Data
+
+- Use VARIANT, OBJECT, and ARRAY types for semi-structured data (JSON, Avro, Parquet, ORC).
+- Access nested fields with colon notation: `src:customer.name::STRING`.
+- Cast extracted values explicitly: `src:price::NUMBER(10,2)`, `src:created_at::TIMESTAMP_NTZ`.
+- For better pruning and less storage, flatten semi-structured data into relational columns when:
+  - Data contains dates/timestamps (especially non-ISO 8601 formats stored as strings in VARIANT).
+  - Data contains numbers stored as strings.
+  - Data contains arrays or non-native values.
+- Use FLATTEN to unnest arrays and nested objects:
+
+```sql
+SELECT f.value:name::STRING AS name
+FROM my_table, LATERAL FLATTEN(input => src:items) f;
+```
+
+- Avoid mixed data types in the same VARIANT field across rows — this prevents subcolumnarization and forces full structure scans.
+- VARIANT null vs SQL NULL: VARIANT stores JSON null as the string "null". Use `TO_VARCHAR()` to convert to SQL NULL. Use STRIP_NULL_VALUES => TRUE on load if JSON nulls mean "missing."
+
+## Performance Optimization
+
+- **Cluster keys**: Define on columns used in WHERE, JOIN, or GROUP BY for very large tables (multi-TB). Range queries benefit most.
+
+```sql
+ALTER TABLE large_events CLUSTER BY (event_date, region);
+```
+
+- **Search Optimization Service**: Enable for point-lookup queries on high-cardinality columns, substring/regex searches, and VARIANT field lookups.
+
+```sql
+ALTER TABLE logs ADD SEARCH OPTIMIZATION ON EQUALITY(sender_ip), SUBSTRING(error_message);
+```
+
+- **Materialized Views**: Use for pre-computing expensive aggregations or frequently queried subsets. Cannot span multiple tables.
+- Prefer `LIMIT` with `ORDER BY` to avoid full sorts on large datasets.
+- Use `RESULT_SCAN(LAST_QUERY_ID())` to reuse prior query results without re-executing.
+- Use query tags for workload attribution:
+
+```sql
+ALTER SESSION SET QUERY_TAG = 'etl_daily_load';
+```
+
+## Time Travel and Data Protection
+
+- Snowflake retains historical data for Time Travel (default 1 day, up to 90 days on Enterprise+).
+
+```sql
+SELECT * FROM my_table AT(TIMESTAMP => '2024-01-15 10:00:00'::TIMESTAMP);
+SELECT * FROM my_table BEFORE(STATEMENT => '<query_id>');
+```
+
+- Use `UNDROP TABLE`, `UNDROP SCHEMA`, `UNDROP DATABASE` to recover dropped objects.
+- Zero-copy cloning for instant, storage-efficient copies:
+
+```sql
+CREATE TABLE my_table_clone CLONE my_table;
+CREATE SCHEMA dev_schema CLONE prod_schema;
+```
+
+## Warehouse Best Practices
+
+- Size warehouses based on query complexity, not data volume. Start with X-Small and scale up.
+- Use multi-cluster warehouses for concurrency scaling (auto-scale mode).
+- Set `AUTO_SUSPEND` (e.g., 60 seconds) and `AUTO_RESUME = TRUE` to control costs.
+- Use separate warehouses for different workloads (ETL vs. analytics vs. data science).
+
+## SQL Coding Standards
+
+- Use `snake_case` for all identifiers (tables, columns, schemas).
+- Avoid quoted identifiers unless absolutely necessary.
+- Use CTEs (`WITH` clauses) for readability over deeply nested subqueries.
+- Use `CREATE OR REPLACE` for idempotent DDL in scripts.
+- Use `COPY INTO` for bulk loading from stages, not INSERT for large datasets.
+- Prefer `MERGE` for upsert patterns:
+
+```sql
+MERGE INTO target t USING source s ON t.id = s.id
+WHEN MATCHED THEN UPDATE SET t.name = s.name
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, s.name);
+```
+
+## Stored Procedures (SQL Scripting)
+
+In SQL stored procedures (BEGIN...END blocks), prefix variables and parameters with colon `:` inside SQL statements:
+
+```sql
+CREATE PROCEDURE my_proc(p_id INT)
+RETURNS STRING
+LANGUAGE SQL
+AS
+BEGIN
+  LET result STRING;
+  SELECT name INTO :result FROM users WHERE id = :p_id;
+  RETURN result;
+END;
+```
+
+## Access Control
+
+- Follow least-privilege with role-based access control (RBAC).
+- Use database roles for object-level grants within a database.
+- Use masking policies and row access policies for column-level and row-level security.
+
+## Cost Awareness
+
+- Monitor with `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY` and `WAREHOUSE_METERING_HISTORY`.
+- Use Resource Monitors to set credit limits and alerts.
+- Avoid `SELECT *` on wide tables — columnar storage means scanning fewer columns is cheaper.
+- Use transient tables for staging/temporary data to avoid Fail-safe storage costs.


### PR DESCRIPTION
## Summary

- Adds **4 Snowflake prompt rule sets** — the first data warehouse/data platform rules in the repository.
- **snowflake-sql**: SQL best practices, data pipelines (Dynamic Tables, Streams, Tasks, Snowpipe), semi-structured data, performance optimization, cost management.
- **snowflake-cortex**: Cortex AI Functions (AI_COMPLETE, AI_CLASSIFY, AI_EXTRACT, AI_EMBED, etc.) and Cortex Search for hybrid vector+keyword search and RAG.
- **snowflake-python**: Snowpark Python server-side DataFrames, scalar/vectorized UDFs, UDTFs, stored procedures, pandas on Snowflake.
- **snowflake-dbt**: dbt-snowflake adapter with dynamic table materialization, incremental models, Snowflake-specific configs.

All content is grounded in [official Snowflake documentation](https://docs.snowflake.com).

Each directory follows the CONTRIBUTING.md format:
- `aiprompt.json` with `techStack` (camelCase), `type: "rule"`, and `.mdc` file references
- `rule-snowflake-{name}.mdc` with YAML frontmatter (`description`, `globs`) and markdown body

## Checklist

- [x] Each prompt is in its own `prompts/snowflake-{name}/` directory
- [x] Each contains `aiprompt.json` + `rule-snowflake-{name}.mdc`
- [x] Follows CONTRIBUTING.md format conventions